### PR TITLE
Fix crash when deleting pages on the iPad

### DIFF
--- a/AddPageViewController.swift
+++ b/AddPageViewController.swift
@@ -268,6 +268,7 @@ class AddPageViewController: UIViewController, UITextViewDelegate, UIImagePicker
                 title: titleText,
                 message: nil,
                 preferredStyle: .actionSheet)
+            alertController.popoverPresentationController?.barButtonItem = self.navigationItem.rightBarButtonItems?.last
             
             let overwriteAction = UIAlertAction(title: overwriteActionTitle, style: .destructive, handler: { (action) in
                 if actualPage.permalink == "home" {


### PR DESCRIPTION
Crash was caused by the following error:

> The modalPresentationStyle of a UIAlertController with this style is
> UIModalPresentationPopover. You must provide location information for
> this popover through the alert controller's
> popoverPresentationController. You must provide either a sourceView and
> sourceRect or a barButtonItem. If this information is not known when you
> present the alert controller, you may provide it in the
> UIPopoverPresentationControllerDelegate method
> -prepareForPopoverPresentation.